### PR TITLE
post 方法中初始化 Rquest.Builder 的时候没有传入 url

### DIFF
--- a/ZBLibrary/src/main/java/zuo/biao/library/manager/HttpManager.java
+++ b/ZBLibrary/src/main/java/zuo/biao/library/manager/HttpManager.java
@@ -234,6 +234,7 @@ public class HttpManager {
 					result = getResponseJson(
 							client,
 							new Request.Builder()
+                                    .url(url)
 									.post(requestBody)
 									.build()
 					);


### PR DESCRIPTION
如果post 方法中初始化 Rquest.Builder 的时候没有传入 url, build()方法里面第一句就会抛异常.